### PR TITLE
fix: drop user agent that has been blocked

### DIFF
--- a/speedtest-lite
+++ b/speedtest-lite
@@ -19,11 +19,10 @@
 
 PROGRAMNAME="Speedtest-Lite"
 VERSION="0.2.0"
-AGENT="$PROGRAMNAME/$VERSION"
 
 SPEEDTEST_CONFIG="https://www.speedtest.net/speedtest-config.php"
 SPEEDTEST_SERVERS="https://www.speedtest.net/speedtest-servers-static.php"
-CURL_OPTS="--connect-timeout 10 --user-agent \"$AGENT\""
+CURL_OPTS="--connect-timeout 10"
 NC_OPTS=""
 
 PROG_TEMPFILE=$(which tempfile)


### PR DESCRIPTION
* The user agent declared in the script has been blocked,
  just dropped the custom agent and using the default agent of curl.
  Thanks to Jay Goldberg for suggestion.

  Close #3
